### PR TITLE
Added Magic Link Button to Edit Team Member, 

### DIFF
--- a/src/components/Pages/TeamMembers/Add/Add.js
+++ b/src/components/Pages/TeamMembers/Add/Add.js
@@ -25,7 +25,13 @@ import { withStyles } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
 import Divider from "@material-ui/core/Divider";
-import { styles, MainContainer, MemberInfoContainer } from "./styles.js";
+import {
+  styles,
+  MainContainer,
+  MemberInfoContainer,
+  AddTeamMemberTitleContainer
+} from "./styles.js";
+import Button from "@material-ui/core/Button";
 
 function Add(props) {
   const {
@@ -142,9 +148,23 @@ function Add(props) {
         }
       >
         <Paper className={classes.paper}>
-          <Typography variant="title">
-            {teamMember ? "Edit Team Member" : "Add New Team Member"}
-          </Typography>
+          {/* <div className={classes.}> */}
+          <AddTeamMemberTitleContainer>
+            <Typography variant="title">
+              {teamMember ? "Edit Team Member" : "Add New Team Member"}
+            </Typography>
+            <Button
+              state={state}
+              className={
+                teamMember ? classes.magicLinkButton : classes.hiddenButton
+              }
+              // status={teamMember ? "edit" : "add"}
+              // display={teamMember ? ""}
+            >
+              Send Login Link
+            </Button>
+          </AddTeamMemberTitleContainer>
+          {/* </div> */}
           <Divider className={classes.divider} />
           <MemberInfoContainer>
             <MemberInfoForm

--- a/src/components/Pages/TeamMembers/Add/styles.js
+++ b/src/components/Pages/TeamMembers/Add/styles.js
@@ -56,6 +56,18 @@ export const styles = theme => ({
       color: "white"
     }
   },
+  magicLinkButton: {
+    marginLeft: theme.spacing.unit,
+    background: "#451476",
+    color: "white",
+    "&:hover": {
+      background: "#591a99",
+      color: "white"
+    }
+  },
+  hiddenButton: {
+    display: "none"
+  },
   Editbutton: {
     "margin-left": theme.spacing.unit,
     background: "#451476",
@@ -122,6 +134,12 @@ export const ButtonContainer = styled.div`
   justify-content: center;
 `;
 
+export const AddTeamMemberTitleContainer = styled.div`
+  display: flex;
+  margin-top: 10px;
+  justify-content: space-between;
+`;
+
 export const LoadingImage = styled.img`
   width: 32px;
   height: auto;
@@ -174,9 +192,8 @@ export const SlackButton = styled.button`
     }
   }
   @media (max-width: 590px) {
-      width: 100%;
-      max-width: none;
-      margin: 16px auto 0;
-    }    
+    width: 100%;
+    max-width: none;
+    margin: 16px auto 0;
   }
 `;

--- a/src/components/Pages/TrainingSeries/Add/MessagePageStyles.js
+++ b/src/components/Pages/TrainingSeries/Add/MessagePageStyles.js
@@ -38,7 +38,7 @@ export const styles = theme => ({
 export const MainContainer = styled.div`
   margin: 0 auto;
   width: 60%;
-  min-width:470px;
+  min-width: 470px;
   max-width: 700px;
 `;
 


### PR DESCRIPTION
Added Magic Link Button to Edit Team Member, doesn't display in Add Team Member, added styling to make this possible.

# Description

Magic Link Button has been added to Edit Team Member so that an admin can select an existing Team Member and send a Magic Link to their email to allow them to login.  As of now it is not funcitonal, but it is in place.  

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Change status
- [ ] Complete, ready to review and merge

# How Has This Been Tested?


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
