### PR TITLE
Refactored training-series view

### DIFF
--- a/src/components/Pages/TeamMemberDashboard/SimpleTabs.js
+++ b/src/components/Pages/TeamMemberDashboard/SimpleTabs.js
@@ -4,7 +4,7 @@ import AppBar from "@material-ui/core/AppBar";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 
-import TrainingSeries from "./TrainingSeries";
+import TrainingSeries from './trainingSeries/TrainingSeries'
 import AllTrainings from "./AllTrainings";
 import Responses from "./Responses";
 

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/SeriesCard.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/SeriesCard.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles({
+    card: {
+        width: 345
+    },
+    media: {
+        height: 140,
+    },
+});
+
+export default function SeriesCard(props) {
+    const classes = useStyles();
+
+    return (
+    <Card className={classes.card}>
+      <CardActionArea>
+        <CardMedia
+            className={classes.media}
+            image={props.seriesData.image}
+            title={props.seriesData.title}
+        />
+        <CardContent>
+            <Typography gutterBottom variant="h5" component="h2">
+                {props.seriesData.title}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+      <CardActions>
+        <Button size="small" color="primary">
+            View Materials
+                </Button>
+      </CardActions>
+    </Card>
+  );
+}

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
@@ -2,7 +2,10 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { getTrainingSeries } from  'store/actions'
 import Container from '@material-ui/core/Container';
-import ProgressCircle from 'components/UI/Progress/ProgressCircle'
+import SeriesCard from './SeriesCard'
+import ProgressCircle from 'components/UI/Progress/ProgressCircle';
+import './trainingSeries.css'
+
 
 const dummyData = [
   { title:"Hazardous Material Policy", image: 'https://truckerpath.com/uploads/2017/02/HAZMAT.jpg'},
@@ -22,15 +25,18 @@ class TrainingSeries extends React.Component {
       series: [...dummyData]
     })
   }
+
+  openSeries() {
+    
+  }
+
   render() {
     return (
-      <Container maxwidth='false'>
+      <Container maxwidth='lg' className='container' >
         {this.state.series.length > 0 ?
         this.state.series.map((singleSeries, i) => {
           return (
-            <div key={i}>
-              <h3>{singleSeries.title}</h3>
-            </div>
+            <SeriesCard key={i} seriesData={singleSeries} />
           )}):
         <ProgressCircle />}
       </Container>

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/seriesCard.css
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/seriesCard.css
@@ -1,0 +1,3 @@
+.seriesCard {
+    margin: 10px;
+}

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/trainingSeries.css
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/trainingSeries.css
@@ -1,0 +1,4 @@
+.container {
+    display: flex;
+    flex-wrap: wrap;
+}


### PR DESCRIPTION
# Description

I decided to refactor the training series tab a bit to cut off a foreseen state management problem at the pass. 

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

## Change status
- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

It's using dummyData for now. Just log in, and on the team-member dash you should see several training series cards that feel like they want to be clicked. They're not clickable yet.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
