### PR TITLE
Training series modal is now rendering dynamically 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@material-ui/core": "^4.1.0",
     "@material-ui/icons": "^3.0.2",
+    "@microlink/react": "^4.0.1",
     "auth0-js": "^9.10.2",
     "auth0-lock": "^11.16.2",
     "axios": "^0.18.0",

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/Accordion.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/Accordion.js
@@ -7,6 +7,7 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ProgressCircle from 'components/UI/Progress/ProgressCircle';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -18,12 +19,35 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export default function SimpleExpansionPanel() {
+export default function Accordion(props) {
   const classes = useStyles();
 
   return ( 
+    
     <div className = {classes.root} >
-      <ExpansionPanel >
+      {props.messages? 
+        props.messages.filter(message => {
+            return message
+          })
+            .map(message => {
+              return <ExpansionPanel >
+                <ExpansionPanelSummary
+                  expandIcon={<ExpandMoreIcon />}
+                  aria-controls="panel1a-content"
+                  id="panel1a-header">
+                  <Typography className={classes.heading}>
+                    {message.subject}
+                  </Typography>
+                </ExpansionPanelSummary>
+                <ExpansionPanelDetails>
+                  <Typography>
+                    {message.body}
+                  </Typography>
+                </ExpansionPanelDetails>
+              </ExpansionPanel>
+            }) : <ProgressCircle />}
+      
+      {/* <ExpansionPanel >
         <ExpansionPanelSummary 
           expandIcon={<ExpandMoreIcon />}
           aria-controls="panel1a-content"
@@ -63,7 +87,7 @@ export default function SimpleExpansionPanel() {
             Disabled Expansion Panel 
           </Typography> 
         </ExpansionPanelSummary> 
-      </ExpansionPanel> 
+      </ExpansionPanel>  */}
     </div>
   );
 }

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/Accordion.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/Accordion.js
@@ -1,52 +1,54 @@
-import React from 'react';
-import {
-  makeStyles
-} from '@material-ui/core/styles';
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
-import Typography from '@material-ui/core/Typography';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import ProgressCircle from 'components/UI/Progress/ProgressCircle';
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import ExpansionPanel from "@material-ui/core/ExpansionPanel";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import Typography from "@material-ui/core/Typography";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import ProgressCircle from "components/UI/Progress/ProgressCircle";
 
 const useStyles = makeStyles(theme => ({
   root: {
-    width: '100%',
+    width: "100%"
   },
   heading: {
     fontSize: theme.typography.pxToRem(15),
-    fontWeight: theme.typography.fontWeightRegular,
-  },
+    fontWeight: theme.typography.fontWeightRegular
+  }
 }));
 
 export default function Accordion(props) {
   const classes = useStyles();
 
-  return ( 
-    
-    <div className = {classes.root} >
-      {props.messages? 
-        props.messages.filter(message => {
-            return message
+  return (
+    <div className={classes.root}>
+      {props.messages ? (
+        props.messages
+          .filter(message => {
+            return message.training_series_id === props.seriesId;
           })
-            .map(message => {
-              return <ExpansionPanel >
+          .map(message => {
+            return (
+              <ExpansionPanel key={message.id}>
                 <ExpansionPanelSummary
                   expandIcon={<ExpandMoreIcon />}
                   aria-controls="panel1a-content"
-                  id="panel1a-header">
+                  id="panel1a-header"
+                >
                   <Typography className={classes.heading}>
                     {message.subject}
                   </Typography>
                 </ExpansionPanelSummary>
                 <ExpansionPanelDetails>
-                  <Typography>
-                    {message.body}
-                  </Typography>
+                  <Typography>{message.body}</Typography>
                 </ExpansionPanelDetails>
               </ExpansionPanel>
-            }) : <ProgressCircle />}
-      
+            );
+          })
+      ) : (
+        <ProgressCircle />
+      )}
+
       {/* <ExpansionPanel >
         <ExpansionPanelSummary 
           expandIcon={<ExpandMoreIcon />}

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/SeriesGrid.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/SeriesGrid.js
@@ -25,21 +25,21 @@ const useStyles = makeStyles(theme => ({
 
 export default function TitlebarGridList(props) {
   const classes = useStyles();
-  
+
   // const clickHandler = (id) => {
   //   props.openSeries(id)
   // }
-  
 
   return (
     <div className={classes.root}>
       <GridList cellHeight={180} className={classes.gridList}>
         <GridListTile key="Subheader" cols={2} style={{ height: "auto" }} />
         {props.seriesData.map(tile => (
-          <GridListTile 
-            onClick={()=>props.openSeries()} 
-            key={tile.id}>
-            <img src="http://lorempixel.com/400/200/business" alt='random image'/>
+          <GridListTile onClick={() => props.openSeries(tile.id)} key={tile.id}>
+            <img
+              src="http://lorempixel.com/400/200/business"
+              alt="random business"
+            />
             <GridListTileBar
               title={tile.title}
               actionIcon={

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/SeriesModal.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/SeriesModal.js
@@ -2,7 +2,6 @@ import React from "react";
 import Button from "@material-ui/core/Button";
 import Accordion from "./Accordion";
 import { makeStyles } from "@material-ui/core/styles";
-import Modal from "@material-ui/core/Modal";
 import './seriesModal.css'
 
 const useStyles = makeStyles(theme => ({
@@ -20,6 +19,8 @@ function SeriesModal(props) {
   const showHideClassName = props.show
     ? "modal display-block"
     : "modal display-none";
+
+  
   return (
     <div className={showHideClassName}>
       <Button
@@ -29,7 +30,10 @@ function SeriesModal(props) {
       >
         Go Back
       </Button>
-      <Accordion />
+      <Accordion 
+        messages={props.messages}
+        seriesId={props.seriesId}
+      />
     </div>
   );
 }

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
@@ -8,39 +8,29 @@ import ProgressCircle from 'components/UI/Progress/ProgressCircle';
 import './trainingSeries.css'
 import axios from 'axios'
 
-
-// const dummyData = [
-//   { title:"Hazardous Material Policy", image: 'https://truckerpath.com/uploads/2017/02/HAZMAT.jpg', id: 1},
-//   { title:"Taxes and Witholding", image: 'https://www.gannett-cdn.com/-mm-/73d0c51d7092d111f30c6c876cceb8310bcb4ec2/c=0-34-580-360&r=x803&c=1600x800/local/-/media/2017/11/02/USATODAY/usatsports/tax-1040-with-money_large.jpg', id: 2},
-//   { title: "Vacation and Time Off", image: 'http://www.30aluxuryvacations.com/sites/default/files/styles/homepage_slideshow_big/public/slides/slideshow-chairs.jpg?itok=6sZeBUHM', id: 3},
-//   { title: "Company Computer Policy", image: 'https://images.pond5.com/young-businesswoman-working-computer-office-footage-018091108_prevstill.jpeg', id: 4},
-//   { title: "Your Fidelity 401k", image: 'https://fidelitylogin.org/wp-content/uploads/2018/01/Fidelity-Investments-Login.jpg', id: 5}
-// ];
-
 class TrainingSeries extends React.Component {
   constructor(props){
     super(props)
     this.state = {
       series: [],
       seriesModal: false,
-      seriesClicked: 0
+      seriesClicked: -1
     }
-    // this.openSeriesModal = this.openSeriesModal.bind(this)
-    // this.closeSeriesModal = this.closeSeriesModal.bind(this)
   }
 
-  componentDidMount=()=> {
-    axios.get(`${process.env.REACT_APP_API}/api/training-series`)
-    .then(res =>
-      this.setState({
-        ...this.state,
-        ...res.data
-      })
-      )
+  async componentDidMount() {
+    const mySeries = await axios.get(`${process.env.REACT_APP_API}/api/training-series`);
+    console.log(`Check out this mySeries object: `, mySeries.data)
+    const myMessages = await axios.get(`${process.env.REACT_APP_API}/api/messages`)
+    console.log(`Check out this myMessages object: `, myMessages.data)
+    this.setState({
+      trainingSeries: mySeries.data.trainingSeries,
+      messages: myMessages.data.messages
+    })
   }
 
   openSeriesModal = (id) => {
-    console.log(`state = ${this.state}`)
+    console.log(`state = `, this.state)
     this.setState({
       ...this.state,
       seriesModal: true,
@@ -48,7 +38,7 @@ class TrainingSeries extends React.Component {
   })
 }
 
-  closeSeriesModal = (id) => {
+  closeSeriesModal = () => {
     console.log('Hello from closeSeriesModal')
     this.setState({
       ...this.state,
@@ -65,6 +55,7 @@ class TrainingSeries extends React.Component {
           seriesData={this.state.trainingSeries}/>:
         <ProgressCircle />}
         <SeriesModal 
+          messages={this.state.messages}
           seriesId={this.state.seriesClicked}
           show={this.state.seriesModal}
           handleClose={this.closeSeriesModal}

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
@@ -1,71 +1,82 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { getTrainingSeries } from  'store/actions'
-import SeriesGrid from './SeriesGrid';
-import SeriesModal from './SeriesModal';
-import Container from '@material-ui/core/Container';
-import ProgressCircle from 'components/UI/Progress/ProgressCircle';
-import './trainingSeries.css'
-import axios from 'axios'
+import React from "react";
+import { connect } from "react-redux";
+import { getTrainingSeries } from "store/actions";
+import SeriesGrid from "./SeriesGrid";
+import SeriesModal from "./SeriesModal";
+import Container from "@material-ui/core/Container";
+import ProgressCircle from "components/UI/Progress/ProgressCircle";
+import "./trainingSeries.css";
+import axios from "axios";
 
 class TrainingSeries extends React.Component {
-  constructor(props){
-    super(props)
+  constructor(props) {
+    super(props);
     this.state = {
       series: [],
       seriesModal: false,
       seriesClicked: -1
-    }
+    };
   }
 
   async componentDidMount() {
-    const mySeries = await axios.get(`${process.env.REACT_APP_API}/api/training-series`);
-    console.log(`Check out this mySeries object: `, mySeries.data)
-    const myMessages = await axios.get(`${process.env.REACT_APP_API}/api/messages`)
-    console.log(`Check out this myMessages object: `, myMessages.data)
+    const mySeries = await axios.get(
+      `${process.env.REACT_APP_API}/api/training-series`
+    );
+    console.log(`Check out this mySeries object: `, mySeries.data);
+    const myMessages = await axios.get(
+      `${process.env.REACT_APP_API}/api/messages`
+    );
+    console.log(`Check out this myMessages object: `, myMessages.data);
     this.setState({
       trainingSeries: mySeries.data.trainingSeries,
       messages: myMessages.data.messages
-    })
+    });
   }
 
-  openSeriesModal = (id) => {
-    console.log(`state = `, this.state)
+  openSeriesModal = id => {
+    console.log("Check out this series id ", id);
+    console.log(`state = `, this.state);
     this.setState({
       ...this.state,
       seriesModal: true,
       seriesClicked: id
-  })
-}
+    });
+  };
 
   closeSeriesModal = () => {
-    console.log('Hello from closeSeriesModal')
+    console.log("Hello from closeSeriesModal");
     this.setState({
       ...this.state,
       seriesModal: false
-    })
-  }
+    });
+  };
 
   render() {
     return (
       <Container>
-        {this.state.trainingSeries  ?
-        <SeriesGrid 
-          openSeries={this.openSeriesModal}
-          seriesData={this.state.trainingSeries}/>:
-        <ProgressCircle />}
-        <SeriesModal 
+        {this.state.trainingSeries ? (
+          <SeriesGrid
+            openSeries={this.openSeriesModal}
+            seriesData={this.state.trainingSeries}
+          />
+        ) : (
+          <ProgressCircle />
+        )}
+        <SeriesModal
           messages={this.state.messages}
           seriesId={this.state.seriesClicked}
           show={this.state.seriesModal}
           handleClose={this.closeSeriesModal}
         />
       </Container>
-    )
+    );
   }
 }
 
 const mapStateToProps = state => ({
   trainingSeries: state.trainingSeriesReducer.trainingSeries
-})
-export default connect(mapStateToProps, { getTrainingSeries })(TrainingSeries)
+});
+export default connect(
+  mapStateToProps,
+  { getTrainingSeries }
+)(TrainingSeries);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,6 +1211,13 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
+"@microlink/react@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@microlink/react/-/react-4.0.1.tgz#3d98c30d24abead327c8731f2757667699553711"
+  integrity sha512-6CAAk4M4vFj+Cpbazw9zIlEpGk2drEjULK/eGjeg/Zhf0ZxTcaMUIYJAYyj6wYr183Wde5to6jFXgfa+8ptD1g==
+  dependencies:
+    nanoclamp "~1.2.11"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -6863,6 +6870,11 @@ nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+nanoclamp@~1.2.11:
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/nanoclamp/-/nanoclamp-1.2.11.tgz#2dc868fad1e31e0e02a0920bc4373c6ff2e74134"
+  integrity sha512-V/g1GXe7mwjR3JiZbs46HJz9gjk2/+uS+HbaxvxuAHwWVGuZx6fkEb+UfIscQ5ZtavYO584W14p+Y0E2RrM9Ag==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
# Description

When you click on a training series, that training-series-id gets passed into a modal. That modal then maps over all of your training messages in the whole wide world and filters out any messages that don't match the training-series-id. It then maps over those filtered messages and renders out accordion tiles for each message.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Change status
- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

I was able to click on a training series and have the modal pop up with the correct set of messages. I can click in and out of this modal repeatedly with no errors. No warnings in the console.

I need more training series to test if this is truly dynamic. Hopefully the series I created yesterday as TrainingBot and assigned to everyone shows up on time. Sometime before lunch today. 
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
