### PR TITLE
Style Responses tab

### DIFF
--- a/src/components/Pages/TeamMemberDashboard/Responses.js
+++ b/src/components/Pages/TeamMemberDashboard/Responses.js
@@ -55,15 +55,15 @@ class Responses extends React.Component {
             this.state.page * this.state.rowsPerPage,
             this.state.page * this.state.rowsPerPage + this.state.rowsPerPage
           )
-          .map(item => (
-            <>
+          .map((item, index) => (
+            <div key={index}>
               <List>
                 <ListItem>
                   <ListItemText primary={item.text} secondary={item.date} />
                 </ListItem>
               </List>
               <Divider light />
-            </>
+            </div>
           ))}
         <TablePagination
           rowsPerPageOptions={[5, 10, 25]}

--- a/src/components/Pages/TeamMemberDashboard/Responses.js
+++ b/src/components/Pages/TeamMemberDashboard/Responses.js
@@ -13,6 +13,7 @@ import Avatar from '@material-ui/core/Avatar'
 import ListItemText from '@material-ui/core/ListItemText'
 import Divider from '@material-ui/core/Divider'
 import TablePagination from '@material-ui/core/TablePagination'
+import Typography from '@material-ui/core/Typography'
 
 const styles = {
   paper: {
@@ -48,7 +49,13 @@ class Responses extends React.Component {
 
     const messages = orderBy([...notif, ...resp], ['date'])
 
-    return (
+    return !messages.length ? (
+      <Paper elevation={2} className={this.props.classes.paper}>
+        <Typography align="center" color="textSecondary">
+          You've had no correspondence with your Admin yet.
+        </Typography>
+      </Paper>
+    ) : (
       <Paper elevation={2} className={this.props.classes.paper}>
         {messages
           .slice(
@@ -60,9 +67,7 @@ class Responses extends React.Component {
               <List>
                 <ListItem>
                   <ListItemAvatar>
-                    <Avatar>
-                      {item.name[0].toUpperCase()}
-                    </Avatar>
+                    <Avatar>{item.name[0].toUpperCase()}</Avatar>
                   </ListItemAvatar>
                   <ListItemText primary={item.text} secondary={item.date} />
                 </ListItem>

--- a/src/components/Pages/TeamMemberDashboard/Responses.js
+++ b/src/components/Pages/TeamMemberDashboard/Responses.js
@@ -5,6 +5,11 @@ import orderBy from 'lodash/orderBy'
 
 import { withStyles } from '@material-ui/styles'
 import Paper from '@material-ui/core/Paper'
+import List from '@material-ui/core/List'
+import ListItem from '@material-ui/core/ListItem'
+import ListItemAvatar from '@material-ui/core/ListItemAvatar'
+import Avatar from '@material-ui/core/Avatar'
+import ListItemText from '@material-ui/core/ListItemText'
 
 const styles = {
   paper: {
@@ -34,9 +39,11 @@ class Responses extends React.Component {
     return (
       <Paper elevation={2} className={this.props.classes.paper}>
         {messages.map(item => (
-          <p>
-            {item.name} | {item.text} | {item.date}
-          </p>
+          <List>
+            <ListItem>
+              <ListItemText primary={item.text} secondary={item.date}/>
+            </ListItem>
+          </List>
         ))}
       </Paper>
     )

--- a/src/components/Pages/TeamMemberDashboard/Responses.js
+++ b/src/components/Pages/TeamMemberDashboard/Responses.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import moment from 'moment'
 import orderBy from 'lodash/orderBy'
 
+// MUI
 import { withStyles } from '@material-ui/styles'
 import Paper from '@material-ui/core/Paper'
 import List from '@material-ui/core/List'
@@ -11,6 +12,7 @@ import ListItemAvatar from '@material-ui/core/ListItemAvatar'
 import Avatar from '@material-ui/core/Avatar'
 import ListItemText from '@material-ui/core/ListItemText'
 import Divider from '@material-ui/core/Divider'
+import TablePagination from '@material-ui/core/TablePagination'
 
 const styles = {
   paper: {
@@ -22,6 +24,15 @@ const styles = {
 }
 
 class Responses extends React.Component {
+  state = {
+    page: 0,
+    rowsPerPage: 5
+  }
+
+  handleChangePage = (event, newPage) => this.setState({ page: newPage })
+  handleChangeRowsPerPage = event =>
+    this.setState({ rowsPerPage: +event.target.value })
+
   render() {
     const notif = this.props.notifications.map(item => ({
       date: moment(item.send_date).format('MMM Do, YYYY, h:mm a'),
@@ -39,16 +50,30 @@ class Responses extends React.Component {
 
     return (
       <Paper elevation={2} className={this.props.classes.paper}>
-        {messages.map(item => (
-          <>
-            <List>
-              <ListItem>
-                <ListItemText primary={item.text} secondary={item.date} />
-              </ListItem>
-            </List>
-            <Divider light />
-          </>
-        ))}
+        {messages
+          .slice(
+            this.state.page * this.state.rowsPerPage,
+            this.state.page * this.state.rowsPerPage + this.state.rowsPerPage
+          )
+          .map(item => (
+            <>
+              <List>
+                <ListItem>
+                  <ListItemText primary={item.text} secondary={item.date} />
+                </ListItem>
+              </List>
+              <Divider light />
+            </>
+          ))}
+        <TablePagination
+          rowsPerPageOptions={[5, 10, 25]}
+          rowsPerPage={this.state.rowsPerPage}
+          page={this.state.page}
+          count={messages.length}
+          onChangePage={this.handleChangePage}
+          onChangeRowsPerPage={this.handleChangeRowsPerPage}
+          component="div"
+        />
       </Paper>
     )
   }

--- a/src/components/Pages/TeamMemberDashboard/Responses.js
+++ b/src/components/Pages/TeamMemberDashboard/Responses.js
@@ -59,6 +59,11 @@ class Responses extends React.Component {
             <div key={index}>
               <List>
                 <ListItem>
+                  <ListItemAvatar>
+                    <Avatar>
+                      {item.name[0].toUpperCase()}
+                    </Avatar>
+                  </ListItemAvatar>
                   <ListItemText primary={item.text} secondary={item.date} />
                 </ListItem>
               </List>

--- a/src/components/Pages/TeamMemberDashboard/Responses.js
+++ b/src/components/Pages/TeamMemberDashboard/Responses.js
@@ -10,6 +10,7 @@ import ListItem from '@material-ui/core/ListItem'
 import ListItemAvatar from '@material-ui/core/ListItemAvatar'
 import Avatar from '@material-ui/core/Avatar'
 import ListItemText from '@material-ui/core/ListItemText'
+import Divider from '@material-ui/core/Divider'
 
 const styles = {
   paper: {
@@ -39,11 +40,14 @@ class Responses extends React.Component {
     return (
       <Paper elevation={2} className={this.props.classes.paper}>
         {messages.map(item => (
-          <List>
-            <ListItem>
-              <ListItemText primary={item.text} secondary={item.date}/>
-            </ListItem>
-          </List>
+          <>
+            <List>
+              <ListItem>
+                <ListItemText primary={item.text} secondary={item.date} />
+              </ListItem>
+            </List>
+            <Divider light />
+          </>
         ))}
       </Paper>
     )

--- a/src/components/Pages/TeamMemberDashboard/Responses.js
+++ b/src/components/Pages/TeamMemberDashboard/Responses.js
@@ -3,6 +3,18 @@ import { connect } from 'react-redux'
 import moment from 'moment'
 import orderBy from 'lodash/orderBy'
 
+import { withStyles } from '@material-ui/styles'
+import Paper from '@material-ui/core/Paper'
+
+const styles = {
+  paper: {
+    margin: '5px auto',
+    padding: '16px',
+    height: '100%',
+    width: '95%'
+  }
+}
+
 class Responses extends React.Component {
   render() {
     const notif = this.props.notifications.map(item => ({
@@ -20,13 +32,13 @@ class Responses extends React.Component {
     const messages = orderBy([...notif, ...resp], ['date'])
 
     return (
-      <>
+      <Paper elevation={2} className={this.props.classes.paper}>
         {messages.map(item => (
           <p>
             {item.name} | {item.text} | {item.date}
           </p>
         ))}
-      </>
+      </Paper>
     )
   }
 }
@@ -39,4 +51,4 @@ const mapStateToProps = state => ({
 export default connect(
   mapStateToProps,
   null
-)(Responses)
+)(withStyles(styles)(Responses))

--- a/src/components/Pages/TeamMemberDashboard/SimpleTabs.js
+++ b/src/components/Pages/TeamMemberDashboard/SimpleTabs.js
@@ -12,10 +12,7 @@ import Tab from '@material-ui/core/Tab'
 const styles = {
   tabs: {
     background: 'white',
-    color: 'black',
-    width: '100vw',
-    display: 'flex',
-    justifyContent: 'center'
+    color: 'black'
   }
 }
 
@@ -35,10 +32,11 @@ class SimpleTabs extends React.Component {
       <>
         <AppBar position="static">
           <Tabs
-            indicatorColor="primary"
-            textColor="primary"
             value={this.state.value}
             onChange={this.changeTab}
+            indicatorColor="primary"
+            textColor="primary"
+            centered
             className={this.props.classes.tabs}
           >
             <Tab label="Training Series" />

--- a/src/components/Pages/TeamMemberDashboard/SimpleTabs.js
+++ b/src/components/Pages/TeamMemberDashboard/SimpleTabs.js
@@ -1,57 +1,57 @@
-import React from "react";
-
-import AppBar from "@material-ui/core/AppBar";
-import Tabs from "@material-ui/core/Tabs";
-import Tab from "@material-ui/core/Tab";
+import React from 'react'
 
 import TrainingSeries from './trainingSeries/TrainingSeries'
-import AllTrainings from "./AllTrainings";
-import Responses from "./Responses";
+import AllTrainings from './AllTrainings'
+import Responses from './Responses'
 
-// import { withStyles } from "@material-ui/core/styles";
+import { withStyles } from '@material-ui/core/styles'
+import AppBar from '@material-ui/core/AppBar'
+import Tabs from '@material-ui/core/Tabs'
+import Tab from '@material-ui/core/Tab'
 
-import styled from "styled-components";
+const styles = {
+  tabs: {
+    background: 'white',
+    color: 'black',
+    width: '100vw',
+    display: 'flex',
+    justifyContent: 'center'
+  }
+}
 
 class SimpleTabs extends React.Component {
   state = {
     value: 0
-  };
+  }
 
   changeTab = (event, newValue) => {
     this.setState({
       value: newValue
-    });
-  };
+    })
+  }
 
   render() {
     return (
       <>
         <AppBar position="static">
-          <TabsStyled
+          <Tabs
             indicatorColor="primary"
             textColor="primary"
             value={this.state.value}
             onChange={this.changeTab}
+            className={this.props.classes.tabs}
           >
             <Tab label="Training Series" />
             <Tab label="All Trainings" />
             <Tab label="Responses" />
-          </TabsStyled>
+          </Tabs>
         </AppBar>
         {this.state.value === 0 && <TrainingSeries />}
         {this.state.value === 1 && <AllTrainings />}
         {this.state.value === 2 && <Responses />}
       </>
-    );
+    )
   }
 }
 
-const TabsStyled = styled(Tabs)`
-  background: white;
-  color: black;
-  width: 100vw;
-  display: flex;
-  justify-content: center;
-`;
-
-export default SimpleTabs;
+export default withStyles(styles)(SimpleTabs)

--- a/src/components/Pages/TeamMemberDashboard/TeamMemberDashboard.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberDashboard.js
@@ -17,6 +17,10 @@ class TeamMemberDashboard extends Component {
 
   componentDidMount() {
     lock.on('authenticated', this.setTokens)
+
+    if (localStorage.getItem('Profile')) {
+      this.setState({ authDone: true })
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
- Styled Responses with MUI to match the provided wireframe
- Already responsive, provided by MUI
- Cleared console warnings on this tab 
- Style for when there is data:
![Screen Shot 2019-06-19 at 2 29 40 PM](https://user-images.githubusercontent.com/4283962/59802984-07cf6b00-929f-11e9-821a-9b1e711c3f15.png)
- Style for when there is no data:
![Screen Shot 2019-06-19 at 2 30 38 PM](https://user-images.githubusercontent.com/4283962/59802995-128a0000-929f-11e9-95f2-328293a10dac.png)

