### PR TITLE
Solved the training series data riddle

### DIFF
--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/SeriesGrid.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/SeriesGrid.js
@@ -35,6 +35,7 @@ export default function TitlebarGridList(props) {
       <GridList cellHeight={180} className={classes.gridList}>
         <GridListTile key="Subheader" cols={2} style={{ height: "auto" }} />
         {props.seriesData.map(tile => (
+          console.log(tile),
           <GridListTile onClick={() => props.openSeries(tile.id)} key={tile.id}>
             <img
               src="http://lorempixel.com/400/200/business"

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
@@ -26,11 +26,6 @@ class TrainingSeries extends React.Component {
           seriesArr.push(notifs[i].training_series_id);
         }
       }
-      // for (let i = 0; i < notifs.length; i++) {
-      //   seriesArr.indexOf(notifs[i].training_series_id) >= 0
-      //     ? console.log(seriesArr)
-      //     : seriesArr.push(notifs[i].training_series_id);
-      // }
       return seriesArr;
     };
     let mySeries = getSeries();
@@ -46,18 +41,19 @@ class TrainingSeries extends React.Component {
           });
       });
     };
-    let seriesArray = [];
     const getSeriesArray = async () => {
+      let seriesArray = [];
       for (let i = 0; i < mySeries.length; i++) {
         await getSeriesInfo(mySeries[i]).then(res => {
           return seriesArray.push(res.trainingSeries);
         });
       }
+      return seriesArray;
     };
     let finalSeries = await getSeriesArray();
     this.setState({
       ...this.state,
-      trainingSeries: seriesArray
+      trainingSeries: finalSeries
     });
   }
 

--- a/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
+++ b/src/components/Pages/TeamMemberDashboard/trainingSeries/TrainingSeries.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { connect } from "react-redux";
-import { getTrainingSeries } from "store/actions";
 import SeriesGrid from "./SeriesGrid";
 import SeriesModal from "./SeriesModal";
 import Container from "@material-ui/core/Container";
@@ -12,39 +11,73 @@ class TrainingSeries extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      series: [],
       seriesModal: false,
-      seriesClicked: -1
+      seriesClicked: -1,
+      filteredNotifications: []
     };
   }
 
   async componentDidMount() {
-    const mySeries = await axios.get(
-      `${process.env.REACT_APP_API}/api/training-series`
-    );
-    console.log(`Check out this mySeries object: `, mySeries.data);
-    const myMessages = await axios.get(
-      `${process.env.REACT_APP_API}/api/messages`
-    );
-    console.log(`Check out this myMessages object: `, myMessages.data);
+    const getSeries = () => {
+      let notifs = this.props.notifications;
+      let seriesArr = [];
+      for (let i = 0; i < notifs.length; i++) {
+        if (seriesArr.indexOf(notifs[i].training_series_id) < 0) {
+          seriesArr.push(notifs[i].training_series_id);
+        }
+      }
+      // for (let i = 0; i < notifs.length; i++) {
+      //   seriesArr.indexOf(notifs[i].training_series_id) >= 0
+      //     ? console.log(seriesArr)
+      //     : seriesArr.push(notifs[i].training_series_id);
+      // }
+      return seriesArr;
+    };
+    let mySeries = getSeries();
+    const getSeriesInfo = num => {
+      return new Promise((resolve, reject) => {
+        axios
+          .get(`${process.env.REACT_APP_API}/api/training-series/${num}`)
+          .then(response => {
+            return resolve(response.data);
+          })
+          .catch(error => {
+            return reject(error.message);
+          });
+      });
+    };
+    let seriesArray = [];
+    const getSeriesArray = async () => {
+      for (let i = 0; i < mySeries.length; i++) {
+        await getSeriesInfo(mySeries[i]).then(res => {
+          return seriesArray.push(res.trainingSeries);
+        });
+      }
+    };
+    let finalSeries = await getSeriesArray();
     this.setState({
-      trainingSeries: mySeries.data.trainingSeries,
-      messages: myMessages.data.messages
+      ...this.state,
+      trainingSeries: seriesArray
     });
   }
 
   openSeriesModal = id => {
-    console.log("Check out this series id ", id);
-    console.log(`state = `, this.state);
+    const sortNotifications = () => {
+      let sorted = this.props.notifications.filter(
+        notif => notif.training_series_id === id
+      );
+      return sorted;
+    };
+    let filteredNotifications = sortNotifications();
     this.setState({
       ...this.state,
       seriesModal: true,
-      seriesClicked: id
+      seriesClicked: id,
+      filteredNotifications: filteredNotifications
     });
   };
 
   closeSeriesModal = () => {
-    console.log("Hello from closeSeriesModal");
     this.setState({
       ...this.state,
       seriesModal: false
@@ -63,7 +96,7 @@ class TrainingSeries extends React.Component {
           <ProgressCircle />
         )}
         <SeriesModal
-          messages={this.state.messages}
+          messages={this.state.filteredNotifications}
           seriesId={this.state.seriesClicked}
           show={this.state.seriesModal}
           handleClose={this.closeSeriesModal}
@@ -74,9 +107,9 @@ class TrainingSeries extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  trainingSeries: state.trainingSeriesReducer.trainingSeries
+  notifications: state.userReducer.userProfile.notificationsFromAdmin
 });
 export default connect(
   mapStateToProps,
-  { getTrainingSeries }
+  null
 )(TrainingSeries);


### PR DESCRIPTION
# Description

The training series tab pulls in all notifications for a team member, then parses them out into "training series" topics. It renders a clickable card for every "training series" topic. When clicked, it opens into an accordion modal with all notifications relevant to that topic. The logic involved was rather tricky, but it runs smoothly now. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Change status

- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

With copious amounts of console logs, which have all been cleaned up and swept away now that it's working.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
