### PR TITLE
App Bar for Team Member Dashboard

### DIFF
--- a/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
@@ -26,7 +26,7 @@ class TeamMemberAppBar extends React.Component {
         <Toolbar>
           <Grid container justify="flex-start" alignContent="center">
             <Grid item xs={12} sm={6} md={8} lg={9}>
-              <IconButton aria-label="Home">
+              <IconButton disabled aria-label="Logo">
                 <img
                   src={Logo}
                   alt="A cute, personable robot"

--- a/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
@@ -12,48 +12,76 @@ import IconButton from '@material-ui/core/IconButton'
 import Avatar from '@material-ui/core/Avatar'
 import HelpOutline from '@material-ui/icons/HelpOutline'
 import Grid from '@material-ui/core/Grid'
+import Modal from '@material-ui/core/Modal'
+import Typography from '@material-ui/core/Typography'
 
 const styles = {
   logo: {
     height: '35px'
+  },
+  modal: {
+    backgroundColor: 'white',
+    outline: 'none',
+    width: '50%',
+    height: '50vh',
+    margin: '20vh auto'
   }
 }
 
 class TeamMemberAppBar extends React.Component {
+  state = {
+    openModal: false
+  }
+
   render() {
     return (
-      <AppBar position="static" color="default">
-        <Toolbar>
-          <Grid container justify="flex-start" alignContent="center">
-            <Grid item xs={12} sm={6} md={8} lg={9}>
-              <IconButton disabled aria-label="Logo">
-                <img
-                  src={Logo}
-                  alt="A cute, personable robot"
-                  className={this.props.classes.logo}
-                />
-              </IconButton>
-              <IconButton color="inherit" aria-label="Help">
-                <HelpOutline />
-              </IconButton>
+      <>
+        <AppBar position="static" color="default">
+          <Toolbar>
+            <Grid container justify="flex-start" alignContent="center">
+              <Grid item xs={12} sm={6} md={8} lg={9}>
+                <IconButton disabled aria-label="Logo">
+                  <img
+                    src={Logo}
+                    alt="A cute, personable robot"
+                    className={this.props.classes.logo}
+                  />
+                </IconButton>
+                <IconButton
+                  onClick={() => this.setState({ openModal: true })}
+                  color="inherit"
+                  aria-label="Help"
+                >
+                  <HelpOutline />
+                </IconButton>
+              </Grid>
             </Grid>
-          </Grid>
 
-          <Grid container justify="flex-end" alignContent="center">
-            <Grid item xs={4} sm={3} md={2} lg={1}>
-              <Avatar
-                src={JSON.parse(localStorage.getItem('Profile')).picture}
-                alt={JSON.parse(localStorage.getItem('Profile')).name}
-              />
+            <Grid container justify="flex-end" alignContent="center">
+              <Grid item xs={4} sm={3} md={2} lg={1}>
+                <Avatar
+                  src={JSON.parse(localStorage.getItem('Profile')).picture}
+                  alt={JSON.parse(localStorage.getItem('Profile')).name}
+                />
+              </Grid>
+              <Grid item xs={8} sm={3} md={2} lg={2}>
+                <Button onClick={() => logout()} variant="outlined">
+                  Logout
+                </Button>
+              </Grid>
             </Grid>
-            <Grid item xs={8} sm={3} md={2} lg={2}>
-              <Button onClick={() => logout()} variant="outlined">
-                Logout
-              </Button>
-            </Grid>
-          </Grid>
-        </Toolbar>
-      </AppBar>
+          </Toolbar>
+        </AppBar>
+
+        <Modal
+          open={this.state.openModal}
+          onClose={() => this.setState({ openModal: false })}
+        >
+          <Typography className={this.props.classes.modal}>
+            Text in a modal
+          </Typography>
+        </Modal>
+      </>
     )
   }
 }

--- a/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
@@ -23,9 +23,10 @@ const styles = {
   modal: {
     backgroundColor: 'white',
     outline: 'none',
-    width: '50%',
-    height: '50vh',
-    margin: '20vh auto'
+    width: '40%',
+    height: '35vh',
+    margin: '20vh auto',
+    padding: '20px'
   }
 }
 
@@ -80,9 +81,34 @@ class TeamMemberAppBar extends React.Component {
           open={this.state.openModal}
           onClose={() => this.setState({ openModal: false })}
         >
-          <Typography className={this.props.classes.modal}>
-            Text in a modal
-          </Typography>
+          <div className={this.props.classes.modal}>
+            <Typography variant="h5" align="center" gutterBottom>
+              Welcome to Training Bot!
+            </Typography>
+            <Typography paragraph>
+              Congrats on your new job! Training Bot will assist you step-by-step as you onboard
+              onto your new team.
+            </Typography>
+            <Typography variant="h6" gutterBottom>
+              View Training Topics
+            </Typography>
+            <Typography paragraph>
+              Under 'View Training Topics', you will find a quick overview of
+              the activities, organized by topics, that you must complete during
+              your onboarding period.
+            </Typography>
+            <Typography variant="h6" gutterBottom>
+              View Training Messages
+            </Typography>
+            <Typography paragraph>
+              Under 'View Training Messages', you will find all conversations
+              (via E-mail, SMS or Slack) between you and your Admin. These
+              conversations contain your Admin's messages to you regarding
+              training activities you are expected to complete as part of your
+              onboarding process. They will also contain your responses, if any,
+              to those messages.
+            </Typography>
+          </div>
         </Modal>
       </>
     )

--- a/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
@@ -11,6 +11,7 @@ import Button from '@material-ui/core/Button'
 import IconButton from '@material-ui/core/IconButton'
 import Avatar from '@material-ui/core/Avatar'
 import HelpOutline from '@material-ui/icons/HelpOutline'
+import Grid from '@material-ui/core/Grid'
 
 const styles = {
   logo: {
@@ -23,23 +24,34 @@ class TeamMemberAppBar extends React.Component {
     return (
       <AppBar position="static" color="default">
         <Toolbar>
-          <IconButton edge="start" color="inherit" aria-label="Home">
-            <img
-              src={Logo}
-              alt="A cute, personable robot"
-              className={this.props.classes.logo}
-            />
-          </IconButton>
-          <IconButton edge="start" color="inherit" aria-label="Help">
-            <HelpOutline />
-          </IconButton>
-          <Avatar
-            src={JSON.parse(localStorage.getItem('Profile')).picture}
-            alt={JSON.parse(localStorage.getItem('Profile')).name}
-          />
-          <Button onClick={() => logout()} color="inherit">
-            Logout
-          </Button>
+          <Grid container justify="flex-start" alignContent="center">
+            <Grid item xs={12} sm={6} md={8} lg={9}>
+              <IconButton aria-label="Home">
+                <img
+                  src={Logo}
+                  alt="A cute, personable robot"
+                  className={this.props.classes.logo}
+                />
+              </IconButton>
+              <IconButton color="inherit" aria-label="Help">
+                <HelpOutline />
+              </IconButton>
+            </Grid>
+          </Grid>
+
+          <Grid container justify="flex-end" alignContent="center">
+            <Grid item xs={4} sm={3} md={2} lg={1}>
+              <Avatar
+                src={JSON.parse(localStorage.getItem('Profile')).picture}
+                alt={JSON.parse(localStorage.getItem('Profile')).name}
+              />
+            </Grid>
+            <Grid item xs={8} sm={3} md={2} lg={2}>
+              <Button onClick={() => logout()} variant="outlined">
+                Logout
+              </Button>
+            </Grid>
+          </Grid>
         </Toolbar>
       </AppBar>
     )

--- a/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
@@ -13,6 +13,7 @@ import Avatar from '@material-ui/core/Avatar'
 import HelpOutline from '@material-ui/icons/HelpOutline'
 import Grid from '@material-ui/core/Grid'
 import Modal from '@material-ui/core/Modal'
+import Tooltip from '@material-ui/core/Tooltip'
 import Typography from '@material-ui/core/Typography'
 
 const styles = {
@@ -47,13 +48,15 @@ class TeamMemberAppBar extends React.Component {
                     className={this.props.classes.logo}
                   />
                 </IconButton>
-                <IconButton
-                  onClick={() => this.setState({ openModal: true })}
-                  color="inherit"
-                  aria-label="Help"
-                >
-                  <HelpOutline />
-                </IconButton>
+                <Tooltip title="Help" placement="right">
+                  <IconButton
+                    onClick={() => this.setState({ openModal: true })}
+                    color="inherit"
+                    aria-label="Help"
+                  >
+                    <HelpOutline />
+                  </IconButton>
+                </Tooltip>
               </Grid>
             </Grid>
 

--- a/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
@@ -1,0 +1,49 @@
+import React from 'react'
+
+import { logout } from '../../../Auth/AuthPasswordless'
+import Logo from 'img/training-bot.png'
+
+// MUI
+import { withStyles } from '@material-ui/styles'
+import AppBar from '@material-ui/core/AppBar'
+import Toolbar from '@material-ui/core/Toolbar'
+import Button from '@material-ui/core/Button'
+import IconButton from '@material-ui/core/IconButton'
+import Avatar from '@material-ui/core/Avatar'
+import HelpOutline from '@material-ui/icons/HelpOutline'
+
+const styles = {
+  logo: {
+    height: '35px'
+  }
+}
+
+class TeamMemberAppBar extends React.Component {
+  render() {
+    return (
+      <AppBar position="static">
+        <Toolbar>
+          <IconButton edge="start" color="inherit" aria-label="Home">
+            <img
+              src={Logo}
+              alt="A cute, personable robot"
+              className={this.props.classes.logo}
+            />
+          </IconButton>
+          <IconButton edge="start" color="inherit" aria-label="Help">
+            <HelpOutline />
+          </IconButton>
+          <Avatar
+            src={JSON.parse(localStorage.getItem('Profile')).picture}
+            alt={JSON.parse(localStorage.getItem('Profile')).name}
+          />
+          <Button onClick={() => logout()} color="inherit">
+            Logout
+          </Button>
+        </Toolbar>
+      </AppBar>
+    )
+  }
+}
+
+export default withStyles(styles)(TeamMemberAppBar)

--- a/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
@@ -24,7 +24,7 @@ const styles = {
     backgroundColor: 'white',
     outline: 'none',
     width: '40%',
-    height: '35vh',
+    minHeight: '35vh',
     margin: '20vh auto',
     padding: '20px'
   }

--- a/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberAppBar.js
@@ -21,7 +21,7 @@ const styles = {
 class TeamMemberAppBar extends React.Component {
   render() {
     return (
-      <AppBar position="static">
+      <AppBar position="static" color="default">
         <Toolbar>
           <IconButton edge="start" color="inherit" aria-label="Home">
             <img

--- a/src/components/Pages/TeamMemberDashboard/TeamMemberDashboard.js
+++ b/src/components/Pages/TeamMemberDashboard/TeamMemberDashboard.js
@@ -6,7 +6,7 @@ import { getUser } from 'store/actions/userActions'
 
 import { lock } from 'Auth/AuthPasswordless'
 
-import AppBar from 'components/Navigation/AppBar'
+import TeamMemberAppBar from './TeamMemberAppBar'
 import SimpleTabs from './SimpleTabs'
 
 class TeamMemberDashboard extends Component {
@@ -57,7 +57,7 @@ class TeamMemberDashboard extends Component {
       
       return (
         <>
-          <AppBar />
+          <TeamMemberAppBar />
           <SimpleTabs />
         </>
       )

--- a/src/components/Pages/TeamMemberDashboard/TrainingMessages.js
+++ b/src/components/Pages/TeamMemberDashboard/TrainingMessages.js
@@ -11,12 +11,13 @@ import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemAvatar from '@material-ui/core/ListItemAvatar'
-import Avatar from '@material-ui/core/Avatar'
 import ListItemText from '@material-ui/core/ListItemText'
+import Avatar from '@material-ui/core/Avatar'
 import Collapse from '@material-ui/core/Collapse'
 import Divider from '@material-ui/core/Divider'
 import TablePagination from '@material-ui/core/TablePagination'
 import Typography from '@material-ui/core/Typography'
+import Tooltip from '@material-ui/core/Tooltip'
 
 // Icons
 import ExpandLess from '@material-ui/icons/ExpandLess'
@@ -96,25 +97,31 @@ class TrainingMessages extends React.Component {
                 onClick={() => this.handleClickListItem(notif.id)}
               >
                 {notif.name === 'twilio' && (
-                  <ListItemIcon>
-                    <TextsmsOutlined />
-                  </ListItemIcon>
+                  <Tooltip title="via SMS" placement="top-start">
+                    <ListItemIcon>
+                      <TextsmsOutlined />
+                    </ListItemIcon>
+                  </Tooltip>
                 )}
 
                 {notif.name === 'sendgrid' && (
-                  <ListItemIcon>
-                    <EmailOutlined />
-                  </ListItemIcon>
+                  <Tooltip title="via Email" placement="top-start">
+                    <ListItemIcon>
+                      <EmailOutlined />
+                    </ListItemIcon>
+                  </Tooltip>
                 )}
 
                 {notif.name === 'slack' && (
-                  <ListItemIcon>
-                    <img
-                      className={this.props.classes.slack}
-                      src={slack_black_logo}
-                      alt="monochrome Slack app logo"
-                    />
-                  </ListItemIcon>
+                  <Tooltip title="via Slack" placement="top-start">
+                    <ListItemIcon>
+                      <img
+                        className={this.props.classes.slack}
+                        src={slack_black_logo}
+                        alt="monochrome Slack app logo"
+                      />
+                    </ListItemIcon>
+                  </Tooltip>
                 )}
 
                 <ListItemText


### PR DESCRIPTION
- Pop opens help modal with meaningful content for an onboarding team member 
- Logo click is disabled since the user will always be on /team-member and there will never be any activity that will change that path
- Help modal is styled responsively
- App bar is styled responsively
- Add tooltip on help icon in the app bar and email, SMS, slack icons under View Training Messages