### PR TITLE
Fix longer messages clashing with date placement

### DIFF
--- a/src/components/Pages/TeamMemberDashboard/TrainingMessages.js
+++ b/src/components/Pages/TeamMemberDashboard/TrainingMessages.js
@@ -6,15 +6,16 @@ import { getNotificationResponses } from '../../../store/actions'
 
 // MUI
 import { withStyles } from '@material-ui/styles'
-import Paper from '@material-ui/core/Paper'
+import Avatar from '@material-ui/core/Avatar'
+import Collapse from '@material-ui/core/Collapse'
+import Divider from '@material-ui/core/Divider'
+import Grid from '@material-ui/core/Grid'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemAvatar from '@material-ui/core/ListItemAvatar'
 import ListItemText from '@material-ui/core/ListItemText'
-import Avatar from '@material-ui/core/Avatar'
-import Collapse from '@material-ui/core/Collapse'
-import Divider from '@material-ui/core/Divider'
+import Paper from '@material-ui/core/Paper'
 import TablePagination from '@material-ui/core/TablePagination'
 import Typography from '@material-ui/core/Typography'
 import Tooltip from '@material-ui/core/Tooltip'
@@ -124,15 +125,26 @@ class TrainingMessages extends React.Component {
                   </Tooltip>
                 )}
 
-                <ListItemText
-                  primary={`${notif.subject} | ${notif.series}`}
-                  secondary={notif.body}
-                />
+                <Grid
+                  container
+                  alignItems="center"
+                  alignContent="center"
+                  justify="space-between"
+                >
+                  <Grid item sm={12} md={9}>
+                    <ListItemText
+                      primary={`${notif.subject} | ${notif.series}`}
+                      secondary={notif.body}
+                    />
+                  </Grid>
 
-                <Typography color="textSecondary">
-                  {moment(notif.send_date).format('MMMM Do, YYYY')}
-                </Typography>
-
+                  <Grid item sm="auto" md="auto">
+                    <Typography color="textSecondary">
+                      {moment(notif.send_date).format('MMMM Do, YYYY')}
+                    </Typography>
+                  </Grid>
+                </Grid>
+                
                 {this.state.showNotifId === notif.id ? (
                   <ExpandLess />
                 ) : (


### PR DESCRIPTION
Before [Desktop]:
<img width="1610" alt="Screen Shot 2019-06-26 at 3 37 15 PM" src="https://user-images.githubusercontent.com/4283962/60223125-bee65c00-9834-11e9-8a85-99ab9f6d7a23.png">

After [Desktop]:
<img width="1627" alt="Screen Shot 2019-06-26 at 5 04 11 PM" src="https://user-images.githubusercontent.com/4283962/60223168-f48b4500-9834-11e9-891f-fe0e12931a79.png">

Before [Mobile]:
<img width="362" alt="Screen Shot 2019-06-26 at 3 58 20 PM" src="https://user-images.githubusercontent.com/4283962/60223154-dae9fd80-9834-11e9-8eef-3bba82a41c0d.png">

After [Mobile]:
<img width="487" alt="Screen Shot 2019-06-26 at 5 04 59 PM" src="https://user-images.githubusercontent.com/4283962/60223185-0ff65000-9835-11e9-9176-3fe64f4da6ec.png">



